### PR TITLE
[ReadonlyArray] `.at()` fix `undefined` issue

### DIFF
--- a/src/entrypoints/array-at.d.ts
+++ b/src/entrypoints/array-at.d.ts
@@ -1,13 +1,13 @@
 /// <reference path="utils.d.ts" />
 
 interface ReadonlyArray<T> {
-	at<const I extends number>(
-	  index: I
-	): TSReset.Equal<I, number> extends true
-	  ? T | undefined
-	  : `${I}` extends `-${infer J extends number}`
-	  ? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
-		? undefined
-		: this[TSReset.Subtract<this["length"], J>]
-	  : this[I];
+  at<const I extends number>(
+    index: I,
+  ): TSReset.Equal<I, number> extends true
+    ? T | undefined
+    : `${I}` extends `-${infer J extends number}`
+    ? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
+      ? undefined
+      : this[TSReset.Subtract<this["length"], J>]
+    : this[I];
 }

--- a/src/entrypoints/array-at.d.ts
+++ b/src/entrypoints/array-at.d.ts
@@ -1,13 +1,20 @@
 /// <reference path="utils.d.ts" />
 
 interface ReadonlyArray<T> {
-  at<const I extends number>(
-    index: I,
+  at<
+    const N extends number,
+    I extends number = `${N}` extends `${infer J extends number}.${number}`
+      ? J
+      : N,
+  >(
+    index: N,
   ): TSReset.Equal<I, number> extends true
     ? T | undefined
     : `${I}` extends `-${infer J extends number}`
-    ? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
-      ? undefined
-      : this[TSReset.Subtract<this["length"], J>]
+    ? TSReset.Subtract<this["length"], J> extends infer K extends number
+      ? [K] extends [never]
+        ? undefined
+        : this[K]
+      : undefined
     : this[I];
 }

--- a/src/entrypoints/array-at.d.ts
+++ b/src/entrypoints/array-at.d.ts
@@ -1,9 +1,13 @@
 /// <reference path="utils.d.ts" />
 
 interface ReadonlyArray<T> {
-	at<I extends number> (index: I): `${I}` extends `-${infer J extends number}`
-		? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
-			? undefined
-			: this[TSReset.Subtract<this["length"], J>]
-		: this[I]
+	at<const I extends number>(
+	  index: I
+	): TSReset.Equal<I, number> extends true
+	  ? T | undefined
+	  : `${I}` extends `-${infer J extends number}`
+	  ? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
+		? undefined
+		: this[TSReset.Subtract<this["length"], J>]
+	  : this[I];
 }

--- a/src/entrypoints/array-at.d.ts
+++ b/src/entrypoints/array-at.d.ts
@@ -11,10 +11,8 @@ interface ReadonlyArray<T> {
   ): TSReset.Equal<I, number> extends true
     ? T | undefined
     : `${I}` extends `-${infer J extends number}`
-    ? TSReset.Subtract<this["length"], J> extends infer K extends number
-      ? [K] extends [never]
-        ? undefined
-        : this[K]
-      : undefined
+    ? `${TSReset.Subtract<this["length"], J>}` extends `-${number}`
+      ? undefined
+      : this[TSReset.Subtract<this["length"], J>]
     : this[I];
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -22,8 +22,15 @@ declare namespace TSReset {
   type BuildTuple<L extends number, T extends any[] = []> = T extends { length: L }
     ? T
     : BuildTuple<L, [...T, any]>
-  
+
   type Subtract<A extends number, B extends number> = BuildTuple<A> extends [...(infer U), ...BuildTuple<B>]
     ? Length<U>
     : never
+
+  type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
+    T,
+  >() => T extends Y ? 1 : 2
+    ? true
+    : false;
+  type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true;
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -21,6 +21,7 @@ declare namespace TSReset {
     ? T
     : BuildTuple<L, [...T, unknown]>;
 
+  // Extra `A extends number` and `B extends number` needed for union types to work Such as Subtract<10 | 20, 1>
   type Subtract<A extends number, B extends number> = A extends number
     ? B extends number
       ? BuildTuple<A> extends [...infer U, ...BuildTuple<B>]

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,36 +1,28 @@
 declare namespace TSReset {
-  type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
-    ? never
-    : T;
+	type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n ? never : T
 
-  type WidenLiteral<T> = T extends string
-    ? string
-    : T extends number
-    ? number
-    : T extends boolean
-    ? boolean
-    : T extends bigint
-    ? bigint
-    : T extends symbol
-    ? symbol
-    : T;
+	type WidenLiteral<T> = T extends string
+		? string
+		: T extends number
+		? number
+		: T extends boolean
+		? boolean
+		: T extends bigint
+		? bigint
+		: T extends symbol
+		? symbol
+		: T
 
-  type Length<T extends any[]> = T extends { length: infer L }
-    ? L
-    : never
+	type BuildTuple<L extends number, T extends any[] = []> = T extends { length: L } ? T : BuildTuple<L, [...T, unknown]>
 
-  type BuildTuple<L extends number, T extends any[] = []> = T extends { length: L }
-    ? T
-    : BuildTuple<L, [...T, any]>
+	type Subtract<A extends number, B extends number> = A extends number
+		? B extends number
+			? BuildTuple<A> extends [...infer U, ...BuildTuple<B>]
+				? U["length"]
+				: never
+			: never	  
+		: never
 
-  type Subtract<A extends number, B extends number> = BuildTuple<A> extends [...(infer U), ...BuildTuple<B>]
-    ? Length<U>
-    : never
-
-  type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <
-    T,
-  >() => T extends Y ? 1 : 2
-    ? true
-    : false;
-  type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true;
+	type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
+	type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
 }

--- a/src/entrypoints/utils.d.ts
+++ b/src/entrypoints/utils.d.ts
@@ -1,28 +1,38 @@
 declare namespace TSReset {
-	type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n ? never : T
+  type NonFalsy<T> = T extends false | 0 | "" | null | undefined | 0n
+    ? never
+    : T;
 
-	type WidenLiteral<T> = T extends string
-		? string
-		: T extends number
-		? number
-		: T extends boolean
-		? boolean
-		: T extends bigint
-		? bigint
-		: T extends symbol
-		? symbol
-		: T
+  type WidenLiteral<T> = T extends string
+    ? string
+    : T extends number
+    ? number
+    : T extends boolean
+    ? boolean
+    : T extends bigint
+    ? bigint
+    : T extends symbol
+    ? symbol
+    : T;
 
-	type BuildTuple<L extends number, T extends any[] = []> = T extends { length: L } ? T : BuildTuple<L, [...T, unknown]>
+  type BuildTuple<L extends number, T extends any[] = []> = T extends {
+    length: L;
+  }
+    ? T
+    : BuildTuple<L, [...T, unknown]>;
 
-	type Subtract<A extends number, B extends number> = A extends number
-		? B extends number
-			? BuildTuple<A> extends [...infer U, ...BuildTuple<B>]
-				? U["length"]
-				: never
-			: never	  
-		: never
+  type Subtract<A extends number, B extends number> = A extends number
+    ? B extends number
+      ? BuildTuple<A> extends [...infer U, ...BuildTuple<B>]
+        ? U["length"]
+        : never
+      : never
+    : never;
 
-	type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y ? 1 : 2 ? true : false
-	type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true
+  type Equal<X, Y> = (<T>() => T extends X ? 1 : 2) extends <T>() => T extends Y
+    ? 1
+    : 2
+    ? true
+    : false;
+  type NotEqual<X, Y> = true extends Equal<X, Y> ? false : true;
 }

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -32,6 +32,32 @@ doNotExecute(async () => {
 
 doNotExecute(async () => {
   const arr = [false, 1, '2'] as const;
+
+  function index() {
+    return Math.random() > 0.5 ? 0 : 1
+  }
+
+  const a = arr.at(index())
+  type tests = [
+    Expect<Equal<typeof a, false | 1>>,
+  ]
+});
+
+doNotExecute(async () => {
+  const arr = [false, true, 1, '2'] as const;
+
+  function index() {
+    return Math.random() > 0.5 ? -1 : -2
+  }
+
+  const a = arr.at(index())
+  type tests = [
+    Expect<Equal<typeof a, '2' | 1>>,
+  ]
+});
+
+doNotExecute(async () => {
+  const arr = [false, 1, '2'] as const;
   const index = 1 as number
   const a = arr.at(index)
   type tests = [

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -7,11 +7,13 @@ doNotExecute(async () => {
   const b = arr.at(1);
   const c = arr.at(2);
   const d = arr.at(3);
+  const e = arr.at(1.5);
   type tests = [
     Expect<Equal<typeof a, false>>,
     Expect<Equal<typeof b, 1>>,
     Expect<Equal<typeof c, "2">>,
     Expect<Equal<typeof d, undefined>>,
+    Expect<Equal<typeof e, 1>>,
   ];
 });
 
@@ -22,11 +24,13 @@ doNotExecute(async () => {
   const b = arr.at(-2);
   const c = arr.at(-3);
   const d = arr.at(-4);
+  const e = arr.at(-1.5);
   type tests = [
     Expect<Equal<typeof a, "2">>,
     Expect<Equal<typeof b, 1>>,
     Expect<Equal<typeof c, false>>,
     Expect<Equal<typeof d, undefined>>,
+    Expect<Equal<typeof e, "2">>,
   ];
 });
 

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -1,66 +1,60 @@
 import { doNotExecute, Equal, Expect } from "./utils";
 
 doNotExecute(async () => {
-  const arr = [false, 1, '2'] as const;
+  const arr = [false, 1, "2"] as const;
 
-  const a = arr.at(0)
-  const b = arr.at(1)
-  const c = arr.at(2)
-  const d = arr.at(3)
+  const a = arr.at(0);
+  const b = arr.at(1);
+  const c = arr.at(2);
+  const d = arr.at(3);
   type tests = [
     Expect<Equal<typeof a, false>>,
     Expect<Equal<typeof b, 1>>,
-    Expect<Equal<typeof c, '2'>>,
+    Expect<Equal<typeof c, "2">>,
     Expect<Equal<typeof d, undefined>>,
-  ]
+  ];
 });
 
 doNotExecute(async () => {
-  const arr = [false, 1, '2'] as const;
+  const arr = [false, 1, "2"] as const;
 
-  const a = arr.at(-1)
-  const b = arr.at(-2)
-  const c = arr.at(-3)
-  const d = arr.at(-4)
+  const a = arr.at(-1);
+  const b = arr.at(-2);
+  const c = arr.at(-3);
+  const d = arr.at(-4);
   type tests = [
-    Expect<Equal<typeof a, '2'>>,
+    Expect<Equal<typeof a, "2">>,
     Expect<Equal<typeof b, 1>>,
     Expect<Equal<typeof c, false>>,
     Expect<Equal<typeof d, undefined>>,
-  ]
+  ];
 });
 
 doNotExecute(async () => {
-  const arr = [false, 1, '2'] as const;
+  const arr = [false, 1, "2"] as const;
 
   function index() {
-    return Math.random() > 0.5 ? 0 : 1
+    return Math.random() > 0.5 ? 0 : 1;
   }
 
-  const a = arr.at(index())
-  type tests = [
-    Expect<Equal<typeof a, false | 1>>,
-  ]
+  const a = arr.at(index());
+  type tests = [Expect<Equal<typeof a, false | 1>>];
 });
 
 doNotExecute(async () => {
-  const arr = [false, true, 1, '2'] as const;
+  const arr = [false, true, 1, "2"] as const;
 
   function index() {
-    return Math.random() > 0.5 ? -1 : -2
+    return Math.random() > 0.5 ? -1 : -2;
   }
 
-  const a = arr.at(index())
-  type tests = [
-    Expect<Equal<typeof a, '2' | 1>>,
-  ]
+  const a = arr.at(index());
+  type tests = [Expect<Equal<typeof a, "2" | 1>>];
 });
 
 doNotExecute(async () => {
-  const arr = [false, 1, '2'] as const;
-  const index = 1 as number
-  const a = arr.at(index)
-  type tests = [
-    Expect<Equal<typeof a, false | 1 | "2" | undefined>>,
-  ]
+  const arr = [false, 1, "2"] as const;
+  const index = 1 as number;
+  const a = arr.at(index);
+  type tests = [Expect<Equal<typeof a, false | 1 | "2" | undefined>>];
 });

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -32,11 +32,9 @@ doNotExecute(async () => {
 
 doNotExecute(async () => {
   const arr = [false, 1, '2'] as const;
-  const index: number = 1
+  const index = 1 as number
   const a = arr.at(index)
-  // WARN: with `"strictNullChecks": true,` the correct type here should include `undefined`
-  // but the current implementation does not type this as including `undefined`
   type tests = [
-    Expect<Equal<typeof a, false | 1 | "2">>,
+    Expect<Equal<typeof a, false | 1 | "2" | undefined>>,
   ]
 });

--- a/src/tests/array-at.ts
+++ b/src/tests/array-at.ts
@@ -37,22 +37,18 @@ doNotExecute(async () => {
 doNotExecute(async () => {
   const arr = [false, 1, "2"] as const;
 
-  function index() {
-    return Math.random() > 0.5 ? 0 : 1;
-  }
+  const index = 0 as 0 | 1
 
-  const a = arr.at(index());
+  const a = arr.at(index);
   type tests = [Expect<Equal<typeof a, false | 1>>];
 });
 
 doNotExecute(async () => {
   const arr = [false, true, 1, "2"] as const;
 
-  function index() {
-    return Math.random() > 0.5 ? -1 : -2;
-  }
+  const index = -1 as -1 | -2
 
-  const a = arr.at(index());
+  const a = arr.at(index);
   type tests = [Expect<Equal<typeof a, "2" | 1>>];
 });
 


### PR DESCRIPTION
This will return undefined regardless if `strictNullChecks` is `true` or `false`.

But this is already the behaviour of native `ReadonlyArray` `.at()`.

As seen here:
```ts
interface Array<T> {
    /**
     * Returns the item located at the specified index.
     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
     */
    at(index: number): T | undefined;
}

interface ReadonlyArray<T> {
    /**
     * Returns the item located at the specified index.
     * @param index The zero-based index of the desired code unit. A negative index will count back from the last item.
     */
    at(index: number): T | undefined;
}
```

Also fixed an issue with index union types, and added tests for it.

Issue was being caused by how `Subtract` util type works with unions types:
```ts
type Foo = Subtract<10, 1 | 2> 
// Foo should give `9 | 8` but gives `9` only
```

Also handled the cases where index number is a "float" and not an "int" correctly, based on how `.at()` handles them